### PR TITLE
limit gh concurrency to 1 for tf-apply

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -3,7 +3,9 @@ on:
   push:
     branches:
       - main
-
+  pull_request:
+    types:
+      - opened
 
 concurrency:
   group: terraform-mon-tf-apply
@@ -28,6 +30,10 @@ jobs:
         with:
           terraform_version: "1.12.2"
       - run: terraform init
+      - id: plan
+        run: terraform plan
+        if: github.event_name == 'pull_request'
       - id: apply
+        if: github.event_name != 'pull_request'
         run: terraform apply -auto-approve
 

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
 
+
+concurrency:
+  group: terraform-mon-tf-apply
+  cancel-in-progress: false
+
 permissions:
   id-token: write
 jobs:

--- a/.github/workflows/tf-destroy.yml
+++ b/.github/workflows/tf-destroy.yml
@@ -1,20 +1,12 @@
-name: tf-apply.yml
+name: tf-destroy.yml
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types:
-      - opened
+  workflow_dispatch
 
 concurrency:
   group: terraform-mon-tf
   cancel-in-progress: false
-
-permissions:
-  id-token: write
 jobs:
-  plan_and_apply:
+  tf-destroy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,11 +21,4 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.12.2"
-      - run: terraform init
-      - id: plan
-        run: terraform plan
-        if: github.event_name == 'pull_request'
-      - id: apply
-        if: github.event_name != 'pull_request'
-        run: terraform apply -auto-approve
-
+      - run: terraform destroy -auto-approve


### PR DESCRIPTION
adding in a concurrency group named `terraform-mon-tf-apply` to limit concurrent runs of this workflow to 1. https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/control-the-concurrency-of-workflows-and-jobs